### PR TITLE
Update deploy.suffix and deploy.prototxt

### DIFF
--- a/deploy.prototxt
+++ b/deploy.prototxt
@@ -3099,7 +3099,7 @@ layer {
     }
   }
 }
-layers {
+layer {
   bottom: "loss3/classifier"
   top: "prob"
   name: "prob"

--- a/tools/deploy.suffix
+++ b/tools/deploy.suffix
@@ -1,4 +1,4 @@
-layers {
+layer {
   bottom: "loss3/classifier"
   top: "prob"
   name: "prob"


### PR DESCRIPTION
I don't know about your custom caffe but `layers` is not being used anymore in Caffe, see [this](https://groups.google.com/forum/#!topic/caffe-users/xXU8X6azlGk), just in case someone else tried to use your model and found this error.

Gave following error when trying to read prototxt file:
```
[libprotobuf ERROR google/protobuf/text_format.cc:274] Error parsing text-format caffe.NetParameter: 3105:9: Expected integer or identifier.
F0110 17:22:46.861500 17622 upgrade_proto.cpp:88] Check failed: ReadProtoFromTextFile(param_file, param) Failed to parse NetParameter file: caffe-googlenet-bn/deploy.prototxt
```

Thanks for training it!